### PR TITLE
feat(orchestrator): enable concurrent orchestrator runs via worktree isolation

### DIFF
--- a/.acb/intents/staged.json
+++ b/.acb/intents/staged.json
@@ -1,0 +1,55 @@
+{
+  "acb_manifest_version": "0.1",
+  "commit_sha": "pending",
+  "timestamp": "2026-03-21T12:00:00Z",
+  "intent_groups": [
+    {
+      "id": "worktree-isolation",
+      "title": "Replace in-place checkout with worktree creation in orchestrator Phase 0",
+      "classification": "explicit",
+      "ambiguity_tags": [],
+      "task_grounding": "Orchestrator blocks concurrent runs because it checks out on the active branch. Moving to worktree-based isolation allows multiple orchestrators to run simultaneously.",
+      "file_refs": [
+        { "path": "skills/orchestrator/SKILL.md", "ranges": ["31-95", "525-535", "570-600"], "view_hint": "changed_region" }
+      ]
+    },
+    {
+      "id": "namespaced-run-state",
+      "title": "Namespace all per-run state under .prove/runs/<slug>/",
+      "classification": "explicit",
+      "ambiguity_tags": [],
+      "task_grounding": "Global singleton files (.prove/PROGRESS.md, dispatch-state.json) prevent concurrent orchestrators. Namespacing under runs/<slug>/ isolates each run's state.",
+      "file_refs": [
+        { "path": "skills/orchestrator/SKILL.md", "ranges": ["95-115", "140-165", "470-510"], "view_hint": "changed_region" },
+        { "path": "scripts/dispatch-event.sh", "ranges": ["30-52"], "view_hint": "changed_region" },
+        { "path": "scripts/hooks/session-stop.sh", "ranges": ["16-35"], "view_hint": "changed_region" },
+        { "path": "scripts/notify-test.sh", "ranges": ["67-85"], "view_hint": "changed_region" },
+        { "path": "skills/orchestrator/references/reporter-protocol.md", "ranges": ["209-210"], "view_hint": "changed_region" }
+      ]
+    },
+    {
+      "id": "cleanup-runs-support",
+      "title": "Update cleanup.sh to handle namespaced .prove/runs/ and orchestrator worktrees",
+      "classification": "explicit",
+      "ambiguity_tags": [],
+      "task_grounding": "Cleanup must scan, archive, and remove the new .prove/runs/<slug>/ directories and orchestrator worktrees, while preserving backward compatibility with legacy global files.",
+      "file_refs": [
+        { "path": "scripts/cleanup.sh", "ranges": ["39-90", "95-160", "165-235", "240-340"], "view_hint": "changed_region" }
+      ]
+    },
+    {
+      "id": "commands-concurrent-support",
+      "title": "Update commands and docs to reflect concurrent orchestrator support",
+      "classification": "explicit",
+      "ambiguity_tags": [],
+      "task_grounding": "Commands (progress, autopilot, full-auto) and docs need to reference the new worktree and namespaced paths, and progress must support listing multiple concurrent runs.",
+      "file_refs": [
+        { "path": "commands/progress.md", "ranges": ["1-58"], "view_hint": "changed_region" },
+        { "path": "commands/autopilot.md", "ranges": ["15-35"], "view_hint": "changed_region" },
+        { "path": "commands/full-auto.md", "ranges": ["14-22"], "view_hint": "changed_region" },
+        { "path": "docs/orchestrator.md", "ranges": ["164-165"], "view_hint": "changed_region" },
+        { "path": "skills/handoff/scripts/gather-context.sh", "ranges": ["111-122"], "view_hint": "changed_region" }
+      ]
+    }
+  ]
+}

--- a/commands/autopilot.md
+++ b/commands/autopilot.md
@@ -17,11 +17,12 @@ Load and follow the orchestrator skill (`skills/orchestrator/SKILL.md` from the 
 
 ## Key Behaviors
 
-- Create a feature branch: `orchestrator/<task-slug>`
+- Create a feature branch in its own worktree: `orchestrator/<task-slug>` at `.claude/worktrees/orchestrator-<slug>`
+- Namespace all run state under `.prove/runs/<task-slug>/` (supports concurrent orchestrator runs)
 - Auto-validate after EVERY step (build, tests, lint)
 - Commit after each successful step
 - On validation failure: one retry, then HALT
-- Generate reports in `.prove/reports/<task-slug>/`
+- Generate reports in `.prove/runs/<task-slug>/reports/`
 - Present the final report and review instructions to the user
 
 ## Do NOT
@@ -29,5 +30,5 @@ Load and follow the orchestrator skill (`skills/orchestrator/SKILL.md` from the 
 - Skip validation gates
 - Continue past a failed step (after retry)
 - Force-push or amend commits
-- Make changes on the main branch
+- Make changes on the main branch or check out branches in the main worktree
 - Proceed if requirements are ambiguous — halt and use `AskUserQuestion` to clarify (when discrete options exist) or ask free-form (when open-ended)

--- a/commands/full-auto.md
+++ b/commands/full-auto.md
@@ -17,6 +17,8 @@ Load and follow the orchestrator skill (`skills/orchestrator/SKILL.md` from the 
 1. Run the full-auto requirements gathering flow (PRD generation)
 2. Execute all phases sequentially: Discover -> Plan -> Execute -> Track
 3. Gate on user approval between phases using `AskUserQuestion` (Approve / Request Changes)
-4. Use `isolation: "worktree"` for parallel task execution
-5. Maintain .prove/PROGRESS.md throughout execution
-6. On completion, present a summary and offer to create a PR
+4. Create orchestrator worktree (`.claude/worktrees/orchestrator-<slug>`) — does not touch the main worktree
+5. Namespace run state under `.prove/runs/<slug>/` (enables concurrent orchestrator runs)
+6. Use `isolation: "worktree"` for parallel sub-task execution within the orchestrator worktree
+7. Maintain `.prove/runs/<slug>/PROGRESS.md` throughout execution
+8. On completion, present a summary and offer to create a PR

--- a/commands/progress.md
+++ b/commands/progress.md
@@ -4,15 +4,27 @@ description: Show orchestrator execution status — current wave, task statuses,
 
 # Progress Report
 
-Read the current orchestrator state and present a compact status summary.
+Read the current orchestrator state and present a compact status summary. Supports multiple concurrent orchestrator runs.
 
 ## Steps
 
-1. Check if `.prove/PROGRESS.md` exists
-   - If not, check `.prove/reports/` for any run logs
-   - If neither exists, tell the user: "No active orchestrator run found. Start one with `/prove:orchestrator` or `/prove:full-auto`."
+1. Scan for active orchestrator runs:
+   - Check `.prove/runs/*/PROGRESS.md` for namespaced run directories
+   - Fall back to `.prove/PROGRESS.md` for legacy single-run layout
+   - Check `.prove/reports/` for any run logs
+   - If nothing exists, tell the user: "No active orchestrator run found. Start one with `/prove:orchestrator` or `/prove:full-auto`."
 
-2. If `.prove/PROGRESS.md` exists, read it and extract:
+2. If multiple runs are found, list them all in a summary table first:
+   ```
+   ## Active Orchestrator Runs
+
+   | Slug | Status | Branch | Tasks |
+   |------|--------|--------|-------|
+   | add-auth | In Progress | orchestrator/add-auth | 3/6 complete |
+   | fix-perf | Completed | orchestrator/fix-perf | 4/4 complete |
+   ```
+
+3. For each run (or a single run if only one), read PROGRESS.md and extract:
    - Overall status (In Progress / Completed / Failed / Paused)
    - Current wave number and total waves
    - Per-task status (pending / in-progress / completed / failed)
@@ -20,16 +32,17 @@ Read the current orchestrator state and present a compact status summary.
    - Any items in the Issues section
    - Test results if available
 
-3. Also check `.prove/reports/*/run-log.md` for the most recent report:
+4. Also check `.prove/runs/<slug>/reports/run-log.md` (or legacy `.prove/reports/*/run-log.md`) for the most recent report:
    - Extract the Step Log table
    - Note any WIP or failed steps
 
-4. Present a compact summary:
+5. Present a compact summary per run:
 
 ```
 ## Orchestrator Status: [Feature Name]
 
 **Status**: In Progress | **Branch**: orchestrator/feature-slug
+**Worktree**: .claude/worktrees/orchestrator-feature-slug
 **Wave**: 2/3 | **Tasks**: 4/6 complete
 
 ### Current Wave (Wave 2)
@@ -44,7 +57,7 @@ Read the current orchestrator state and present a compact status summary.
 - None
 ```
 
-5. If the orchestrator is complete, show final stats and merge instructions.
+6. If an orchestrator run is complete, show final stats and merge instructions.
 
 ## Rules
 - Read files only — never modify PROGRESS.md or run-log.md

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -161,7 +161,7 @@ See `skills/orchestrator/references/handoff-protocol.md` for the full protocol.
 
 ### PROGRESS.md
 
-During full mode execution, the orchestrator maintains a live `.prove/PROGRESS.md` tracking wave status, per-task status, review verdicts, merge events, and test results.
+During full mode execution, the orchestrator maintains a live `.prove/runs/<slug>/PROGRESS.md` tracking wave status, per-task status, review verdicts, merge events, and test results. Each orchestrator run has its own namespaced directory, enabling multiple concurrent runs.
 
 ### `/prove:progress`
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -40,6 +40,8 @@ found_reports=()
 found_plans=()
 found_context=()
 found_branches=()
+found_runs=()
+found_worktrees=()
 found_prd=false
 found_task_plan=false
 found_progress=false
@@ -48,9 +50,10 @@ scan_artifacts() {
   local slug="$1"
 
   if [[ -n "$slug" ]]; then
-    # Scan for specific task
+    # Scan for specific task — check namespaced run directory first
+    [[ -d "$PROVE_DIR/runs/$slug" ]] && found_runs+=("$slug") || true
+    # Legacy: also check old-style report/context paths
     [[ -d "$PROVE_DIR/reports/$slug" ]] && found_reports+=("$slug") || true
-    # Plans use plan_* naming — match slug in directory name
     for d in "$PROVE_DIR"/plans/plan_*/; do
       [[ -d "$d" ]] && found_plans+=("$(basename "$d")")
     done
@@ -59,8 +62,14 @@ scan_artifacts() {
     if git branch --list "orchestrator/$slug" 2>/dev/null | grep -q .; then
       found_branches+=("orchestrator/$slug")
     fi
+    # Check orchestrator worktrees
+    local wt_path=".claude/worktrees/orchestrator-$slug"
+    [[ -d "$wt_path" ]] && found_worktrees+=("$wt_path") || true
   else
     # Scan for all artifacts
+    for d in "$PROVE_DIR"/runs/*/; do
+      [[ -d "$d" ]] && found_runs+=("$(basename "$d")")
+    done
     for d in "$PROVE_DIR"/reports/*/; do
       [[ -d "$d" ]] && found_reports+=("$(basename "$d")")
     done
@@ -74,6 +83,10 @@ scan_artifacts() {
       branch=$(echo "$branch" | xargs)  # trim whitespace
       [[ -n "$branch" ]] && found_branches+=("$branch")
     done < <(git branch --list 'orchestrator/*' 2>/dev/null)
+    # Scan orchestrator worktrees
+    for d in .claude/worktrees/orchestrator-*/; do
+      [[ -d "$d" ]] && found_worktrees+=("$d")
+    done
   fi
 
   [[ -f "$PROVE_DIR/PRD.md" ]] && found_prd=true || true
@@ -86,9 +99,15 @@ scan_artifacts() {
 print_found() {
   local count=0
 
+  if [[ ${#found_runs[@]} -gt 0 ]]; then
+    for r in "${found_runs[@]}"; do
+      echo "  run: .prove/runs/$r/"
+      ((count++)) || true
+    done
+  fi
   if [[ ${#found_reports[@]} -gt 0 ]]; then
     for r in "${found_reports[@]}"; do
-      echo "  report: .prove/reports/$r/"
+      echo "  report: .prove/reports/$r/ (legacy)"
       ((count++)) || true
     done
   fi
@@ -113,8 +132,14 @@ print_found() {
     ((count++)) || true
   fi
   if $found_progress; then
-    echo "  file: .prove/PROGRESS.md"
+    echo "  file: .prove/PROGRESS.md (legacy)"
     ((count++)) || true
+  fi
+  if [[ ${#found_worktrees[@]} -gt 0 ]]; then
+    for w in "${found_worktrees[@]}"; do
+      echo "  worktree: $w"
+      ((count++)) || true
+    done
   fi
   if [[ ${#found_branches[@]} -gt 0 ]]; then
     for b in "${found_branches[@]}"; do
@@ -155,14 +180,29 @@ archive_slug() {
   local archive_dir="$PROVE_DIR/archive/${TODAY}_${slug}"
   mkdir -p "$archive_dir"
 
-  # Archive reports
+  # Archive namespaced run directory (new layout)
+  if [[ "$slug" == "all" ]]; then
+    for d in "$PROVE_DIR"/runs/*/; do
+      if [[ -d "$d" ]]; then
+        local rname
+        rname=$(basename "$d")
+        cp -r "$d" "$archive_dir/run-$rname/"
+        echo "  archived: runs/$rname/ -> archive/${TODAY}_${slug}/"
+      fi
+    done
+  elif [[ -d "$PROVE_DIR/runs/$slug" ]]; then
+    cp -r "$PROVE_DIR/runs/$slug/" "$archive_dir/run/"
+    echo "  archived: runs/$slug/ -> archive/${TODAY}_${slug}/"
+  fi
+
+  # Archive legacy reports (pre-concurrent layout)
   if [[ "$slug" == "all" ]]; then
     for d in "$PROVE_DIR"/reports/*/; do
       if [[ -d "$d" ]]; then
         local rname
         rname=$(basename "$d")
         cp -r "$d" "$archive_dir/reports-$rname/"
-        echo "  archived: reports/$rname/ -> archive/${TODAY}_${slug}/"
+        echo "  archived: reports/$rname/ -> archive/${TODAY}_${slug}/ (legacy)"
       fi
     done
   elif [[ -d "$PROVE_DIR/reports/$slug" ]]; then
@@ -170,7 +210,7 @@ archive_slug() {
       cp "$PROVE_DIR/reports/$slug/report.md" "$archive_dir/workflow-report.md"
     [[ -f "$PROVE_DIR/reports/$slug/run-log.md" ]] && \
       cp "$PROVE_DIR/reports/$slug/run-log.md" "$archive_dir/run-log.md"
-    echo "  archived: reports/$slug/ -> archive/${TODAY}_${slug}/"
+    echo "  archived: reports/$slug/ -> archive/${TODAY}_${slug}/ (legacy)"
   fi
 
   # Archive plans (copy key files from any matching plan dirs)
@@ -184,7 +224,7 @@ archive_slug() {
     fi
   done
 
-  # Archive top-level files
+  # Archive top-level files (legacy — these are now copied into runs/<slug>/ at start)
   if [[ -f "$PROVE_DIR/PRD.md" ]]; then
     cp "$PROVE_DIR/PRD.md" "$archive_dir/PRD.md"
     echo "  archived: PRD.md -> archive/${TODAY}_${slug}/"
@@ -218,14 +258,25 @@ remove_artifacts() {
   local remove_all=false
   [[ "$slug" == "all" ]] && remove_all=true
 
-  # Remove reports
+  # Remove namespaced run directories (new layout)
+  if $remove_all; then
+    for d in "$PROVE_DIR"/runs/*/; do
+      [[ -d "$d" ]] && rm -rf "$d" && echo "  removed: .prove/runs/$(basename "$d")/"
+    done
+  elif [[ -d "$PROVE_DIR/runs/$slug" ]]; then
+    rm -rf "$PROVE_DIR/runs/$slug"
+    echo "  removed: .prove/runs/$slug/"
+  fi
+  rmdir "$PROVE_DIR/runs" 2>/dev/null && echo "  removed: .prove/runs/ (empty)" || true
+
+  # Remove legacy reports
   if $remove_all; then
     for d in "$PROVE_DIR"/reports/*/; do
-      [[ -d "$d" ]] && rm -rf "$d" && echo "  removed: .prove/reports/$(basename "$d")/"
+      [[ -d "$d" ]] && rm -rf "$d" && echo "  removed: .prove/reports/$(basename "$d")/ (legacy)"
     done
   elif [[ -d "$PROVE_DIR/reports/$slug" ]]; then
     rm -rf "$PROVE_DIR/reports/$slug"
-    echo "  removed: .prove/reports/$slug/"
+    echo "  removed: .prove/reports/$slug/ (legacy)"
   fi
   rmdir "$PROVE_DIR/reports" 2>/dev/null && echo "  removed: .prove/reports/ (empty)" || true
 
@@ -249,18 +300,41 @@ remove_artifacts() {
   fi
   rmdir "$PROVE_DIR/context" 2>/dev/null && echo "  removed: .prove/context/ (empty)" || true
 
-  # Remove top-level files
-  if [[ -f "$PROVE_DIR/PRD.md" ]]; then
-    rm "$PROVE_DIR/PRD.md"
-    echo "  removed: .prove/PRD.md"
+  # Remove top-level files (legacy — only if no other runs are active)
+  local active_runs=0
+  for d in "$PROVE_DIR"/runs/*/; do
+    [[ -d "$d" ]] && ((active_runs++)) || true
+  done
+
+  if [[ $active_runs -eq 0 ]]; then
+    if [[ -f "$PROVE_DIR/PRD.md" ]]; then
+      rm "$PROVE_DIR/PRD.md"
+      echo "  removed: .prove/PRD.md"
+    fi
+    if [[ -f "$PROVE_DIR/TASK_PLAN.md" ]]; then
+      rm "$PROVE_DIR/TASK_PLAN.md"
+      echo "  removed: .prove/TASK_PLAN.md"
+    fi
+    if [[ -f "$PROVE_DIR/PROGRESS.md" ]]; then
+      rm "$PROVE_DIR/PROGRESS.md"
+      echo "  removed: .prove/PROGRESS.md (legacy)"
+    fi
+  else
+    echo "  kept: .prove/PRD.md, TASK_PLAN.md (other runs still active)"
   fi
-  if [[ -f "$PROVE_DIR/TASK_PLAN.md" ]]; then
-    rm "$PROVE_DIR/TASK_PLAN.md"
-    echo "  removed: .prove/TASK_PLAN.md"
-  fi
-  if [[ -f "$PROVE_DIR/PROGRESS.md" ]]; then
-    rm "$PROVE_DIR/PROGRESS.md"
-    echo "  removed: .prove/PROGRESS.md"
+
+  # Remove orchestrator worktrees
+  if $remove_all; then
+    for d in .claude/worktrees/orchestrator-*/; do
+      if [[ -d "$d" ]]; then
+        git worktree remove "$d" --force 2>/dev/null && echo "  removed worktree: $d" || echo "  SKIPPED worktree: $d (remove failed)"
+      fi
+    done
+  elif [[ -n "$slug" ]]; then
+    local wt_path=".claude/worktrees/orchestrator-$slug"
+    if [[ -d "$wt_path" ]]; then
+      git worktree remove "$wt_path" --force 2>/dev/null && echo "  removed worktree: $wt_path" || echo "  SKIPPED worktree: $wt_path (remove failed)"
+    fi
   fi
 }
 

--- a/scripts/dispatch-event.sh
+++ b/scripts/dispatch-event.sh
@@ -2,7 +2,7 @@
 # dispatch-event.sh — Core event dispatcher for prove orchestrator
 #
 # Reads .prove.json reporters, fires matching ones for the given event,
-# and deduplicates via .prove/dispatch-state.json.
+# and deduplicates via .prove/runs/<slug>/dispatch-state.json.
 #
 # Usage:
 #   PROVE_TASK="my-task" PROVE_STEP="1" PROVE_STATUS="done" \
@@ -29,9 +29,27 @@ MAIN_ROOT=$(git -C "$WORK_DIR" worktree list --porcelain 2>/dev/null | awk '/^wo
 MAIN_ROOT="${MAIN_ROOT:-$WORK_DIR}"
 # Config (.prove.json) is tracked — read from current worktree (guaranteed up-to-date)
 CONFIG_FILE="${WORK_DIR}/.prove.json"
-# State and reporter scripts live in .prove/ (gitignored) — always in main worktree
-STATE_FILE="${MAIN_ROOT}/.prove/dispatch-state.json"
+# Reporter scripts live in .prove/ (gitignored) — always in main worktree
 REPORTER_ROOT="${MAIN_ROOT}"
+
+# Derive run slug from PROVE_TASK env var or branch name for namespaced state
+RUN_SLUG="${PROVE_TASK:-}"
+if [[ -z "$RUN_SLUG" ]]; then
+  BRANCH=$(cd "$WORK_DIR" && git branch --show-current 2>/dev/null || echo "")
+  if [[ "$BRANCH" == orchestrator/* ]]; then
+    RUN_SLUG="${BRANCH#orchestrator/}"
+  fi
+fi
+
+# State is namespaced per run under .prove/runs/<slug>/ (supports concurrent orchestrators)
+if [[ -n "$RUN_SLUG" ]]; then
+  STATE_DIR="${MAIN_ROOT}/.prove/runs/${RUN_SLUG}"
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+  STATE_FILE="${STATE_DIR}/dispatch-state.json"
+else
+  # Fallback for non-orchestrator dispatch (e.g. manual reporter testing)
+  STATE_FILE="${MAIN_ROOT}/.prove/dispatch-state.json"
+fi
 
 # --- Check configuration ---
 

--- a/scripts/hooks/session-stop.sh
+++ b/scripts/hooks/session-stop.sh
@@ -15,7 +15,17 @@ WORK_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # .prove/ is gitignored — always lives in the main worktree
 MAIN_ROOT=$(git -C "$WORK_DIR" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10); exit}')
 MAIN_ROOT="${MAIN_ROOT:-$WORK_DIR}"
-PROGRESS_FILE="${MAIN_ROOT}/.prove/PROGRESS.md"
+
+# Check we're on an orchestrator branch
+BRANCH=$(cd "$WORK_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
+if [[ "$BRANCH" != orchestrator/* ]]; then
+  exit 0
+fi
+
+TASK="${BRANCH#orchestrator/}"
+
+# Progress is namespaced per run under .prove/runs/<slug>/
+PROGRESS_FILE="${MAIN_ROOT}/.prove/runs/${TASK}/PROGRESS.md"
 
 # Only dispatch if there's an active orchestrator run
 if [[ ! -f "$PROGRESS_FILE" ]]; then
@@ -26,14 +36,6 @@ fi
 if ! grep -qi 'Status.*In Progress' "$PROGRESS_FILE" 2>/dev/null; then
   exit 0
 fi
-
-# Check we're on an orchestrator branch
-BRANCH=$(cd "$WORK_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
-if [[ "$BRANCH" != orchestrator/* ]]; then
-  exit 0
-fi
-
-TASK="${BRANCH#orchestrator/}"
 
 # Count completed steps from PROGRESS.md
 COMPLETED=$(grep -c '\[x\]' "$PROGRESS_FILE" 2>/dev/null || echo "0")

--- a/scripts/notify-test.sh
+++ b/scripts/notify-test.sh
@@ -65,8 +65,21 @@ with open(sys.argv[1]) as f:
 fi
 
 # --- Clear dedup state for test ---
+# Derive slug from PROVE_TASK or branch, matching dispatch-event.sh logic
+_TEST_SLUG="${PROVE_TASK:-}"
+if [[ -z "$_TEST_SLUG" ]]; then
+  _TEST_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+  if [[ "$_TEST_BRANCH" == orchestrator/* ]]; then
+    _TEST_SLUG="${_TEST_BRANCH#orchestrator/}"
+  fi
+fi
 
-STATE_FILE=".prove/dispatch-state.json"
+if [[ -n "$_TEST_SLUG" ]]; then
+  STATE_FILE=".prove/runs/${_TEST_SLUG}/dispatch-state.json"
+else
+  STATE_FILE=".prove/dispatch-state.json"
+fi
+
 if [[ -f "$STATE_FILE" ]]; then
   # Back up actual state so it can be restored after the test
   cp "$STATE_FILE" "${STATE_FILE}.bak"

--- a/skills/handoff/scripts/gather-context.sh
+++ b/skills/handoff/scripts/gather-context.sh
@@ -109,9 +109,16 @@ if [[ -f .prove/PRD.md ]]; then
   FOUND_ARTIFACTS=true
 fi
 if [[ -f .prove/PROGRESS.md ]]; then
-  echo "- \`.prove/PROGRESS.md\` — Orchestrator progress tracker"
+  echo "- \`.prove/PROGRESS.md\` — Orchestrator progress tracker (legacy)"
   FOUND_ARTIFACTS=true
 fi
+for run_dir in .prove/runs/*/; do
+  if [[ -d "$run_dir" ]]; then
+    run_slug=$(basename "$run_dir")
+    echo "- \`.prove/runs/$run_slug/\` — Orchestrator run state"
+    FOUND_ARTIFACTS=true
+  fi
+done
 if [[ -d .prove/plans ]]; then
   PLAN_COUNT=$(find .prove/plans -maxdepth 1 -type d | tail -n +2 | wc -l | tr -d ' ')
   if [[ "$PLAN_COUNT" -gt 0 ]]; then

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -3,11 +3,14 @@ name: orchestrator
 description: >
   Autonomous task orchestrator that auto-scales between simple mode (<=3 steps,
   sequential, no worktrees) and full mode (4+ steps, parallel worktrees with
-  mandatory principal-architect review). Creates feature branches, runs validation
-  gates (build, test, lint), commits after each successful step, generates progress
-  reports, and supports rollback via git. Use when a .prove/TASK_PLAN.md or .prove/plans/ directory
-  exists and the user wants hands-off execution. Triggers on "orchestrate", "autopilot",
-  "full auto", "run autonomously", "implement without me", "hands-off mode".
+  mandatory principal-architect review). Each orchestrator run operates in its own
+  git worktree with namespaced state (.prove/runs/<slug>/), enabling multiple
+  concurrent orchestrator runs that consolidate at merge time. Creates feature
+  branches, runs validation gates (build, test, lint), commits after each successful
+  step, generates progress reports, and supports rollback via git. Use when a
+  .prove/TASK_PLAN.md or .prove/plans/ directory exists and the user wants hands-off
+  execution. Triggers on "orchestrate", "autopilot", "full auto", "run autonomously",
+  "implement without me", "hands-off mode".
 ---
 
 # Orchestrator Skill
@@ -41,21 +44,26 @@ If neither exists, inform the user and suggest running `/plan-task` first.
    - **4+ steps**: Full mode (parallel worktrees + architect review)
    - Log which mode was selected
 
-3. **Create feature branch**
-   ```bash
-   git checkout -b orchestrator/<task-slug>
-   ```
-   - Slugify the task name (lowercase, hyphens, no special chars, max 50 chars)
+3. **Create feature branch in a worktree** (enables concurrent orchestrator runs)
+   - Slugify the task name (lowercase, hyphens, no special chars, max 40 chars)
    - If branch already exists, use AskUserQuestion with header "Branch" and options: "Resume" (continue from last commit) / "Start Fresh" (delete and recreate)
+   - Create the branch and worktree:
+     ```bash
+     git worktree add .claude/worktrees/orchestrator-<task-slug> -b orchestrator/<task-slug>
+     ```
+   - All subsequent orchestrator work happens inside this worktree path.
+     The main worktree remains on its current branch, so other orchestrators
+     (or manual work) can run concurrently without interference.
 
-4. **Initialize report directory**
+4. **Initialize run directory** (namespaced per slug — supports concurrent runs)
    ```bash
-   mkdir -p .prove/reports/<task-slug>/
+   mkdir -p .prove/runs/<task-slug>/reports/
    ```
-   Create `.prove/reports/<task-slug>/run-log.md`:
+   Create `.prove/runs/<task-slug>/reports/run-log.md`:
    ```markdown
    # Orchestrator Run Log: <Task Name>
    **Branch**: orchestrator/<task-slug>
+   **Worktree**: .claude/worktrees/orchestrator-<task-slug>
    **Mode**: Simple | Full
    **Started**: <ISO timestamp>
    **Status**: In Progress
@@ -68,6 +76,12 @@ If neither exists, inform the user and suggest running `/plan-task` first.
    ## Step Log
    | # | Step | Status | Commit | Notes |
    |---|------|--------|--------|-------|
+   ```
+
+   Copy planning inputs into the run directory for isolation:
+   ```bash
+   cp .prove/TASK_PLAN.md .prove/runs/<task-slug>/TASK_PLAN.md
+   [[ -f .prove/PRD.md ]] && cp .prove/PRD.md .prove/runs/<task-slug>/PRD.md
    ```
 
 5. **Load validators** from `.prove.json` or auto-detect per `references/validation-config.md`
@@ -88,7 +102,7 @@ Configured in `.claude/settings.json`:
 - **SubagentStop(principal-architect|validation-agent)** — detects review/validation verdicts, dispatches `review-approved`, `review-rejected`, `validation-pass`, `validation-fail`
 - **Stop** — dispatches `execution-complete` when the session ends with an active orchestrator run
 
-All dispatch reads the `reporters` array from `.prove.json` and deduplicates via `.prove/dispatch-state.json`. See `references/reporter-protocol.md` for details.
+All dispatch reads the `reporters` array from `.prove.json` and deduplicates via `.prove/runs/<slug>/dispatch-state.json`. See `references/reporter-protocol.md` for details.
 
 **The orchestrator should focus on execution — notifications happen automatically.**
 
@@ -96,12 +110,12 @@ All dispatch reads the `reporters` array from `.prove.json` and deduplicates via
 
 ## Phase 1: Plan Review
 
-1. **Extract ordered steps** from:
-   - `.prove/TASK_PLAN.md` > "Implementation Steps" section, OR
+1. **Extract ordered steps** from (paths relative to run directory):
+   - `.prove/runs/<slug>/TASK_PLAN.md` > "Implementation Steps" section, OR
    - `.prove/plans/plan_X/05_implementation_plan.md`
 2. **Resolve dependencies** — topological sort if needed
 3. **Map validation criteria** per step from `06_test_strategy.md` and step-level verification items
-4. **Log the execution plan** to run-log.md
+4. **Log the execution plan** to `.prove/runs/<slug>/reports/run-log.md`
 
 ---
 
@@ -131,9 +145,9 @@ For each wave:
 For each task in the wave, generate a prompt and launch:
 
 ```bash
-# Generate the task prompt
+# Generate the task prompt (use run-local copies)
 PROMPT=$(bash scripts/generate-task-prompt.sh \
-  <task-plan-path> <task-id> <prd-path> <project-root>)
+  .prove/runs/<slug>/TASK_PLAN.md <task-id> .prove/runs/<slug>/PRD.md <project-root>)
 ```
 
 Then launch with the Agent tool:
@@ -149,14 +163,14 @@ Agent(
 - Launch ALL tasks in a wave as parallel Agent calls in a single message.
 - Update progress for each task start:
   ```bash
-  bash scripts/update-progress.sh <progress-path> task-start <task-id>
+  bash scripts/update-progress.sh .prove/runs/<slug>/PROGRESS.md task-start <task-id>
   ```
 
 #### 2b. Wait for Completion
 
 Wait for all background agents in the wave to complete. Update progress as each finishes:
 ```bash
-bash scripts/update-progress.sh <progress-path> task-complete <task-id>
+bash scripts/update-progress.sh .prove/runs/<slug>/PROGRESS.md task-complete <task-id>
 ```
 
 #### 2c. Mandatory Architect Review (per task)
@@ -170,7 +184,7 @@ REVIEW LOOP (max 3 iterations per task):
 
 1. Generate review prompt:
    REVIEW_PROMPT=$(bash scripts/generate-review-prompt.sh \
-     <worktree-path> <task-id> <task-plan-path> <prd-path> <base-branch>)
+     <worktree-path> <task-id> .prove/runs/<slug>/TASK_PLAN.md .prove/runs/<slug>/PRD.md <base-branch>)
 
 2. Launch principal-architect review:
    Agent(
@@ -185,7 +199,7 @@ REVIEW LOOP (max 3 iterations per task):
      - Continue to step 4
 
 4. Update progress:
-   bash scripts/update-progress.sh <progress-path> task-review <task-id> "CHANGES_REQUIRED"
+   bash scripts/update-progress.sh .prove/runs/<slug>/PROGRESS.md task-review <task-id> "CHANGES_REQUIRED"
 
 5. Launch a fix agent in the SAME worktree to address review findings:
    Agent(
@@ -207,7 +221,7 @@ REVIEW LOOP (max 3 iterations per task):
 6. Go to step 1 (re-review)
 
 If 3 iterations pass without APPROVED:
-  - Log failure in .prove/PROGRESS.md
+  - Log failure in .prove/runs/<slug>/PROGRESS.md
   - Use AskUserQuestion with header "Resolution" and options: "Force Approve" (merge as-is) / "Fix Manually" (I'll address the findings) / "Abort" (stop the run)
 ```
 
@@ -215,13 +229,14 @@ If 3 iterations pass without APPROVED:
 
 After ALL tasks in the wave are reviewed and approved:
 
-1. For each approved task (in task order):
+1. For each approved task (in task order), merge into the orchestrator worktree:
    ```bash
+   cd .claude/worktrees/orchestrator-<slug>
    git merge <worktree-branch> --no-ff -m "merge: task <id> - <name>"
    ```
    Update progress:
    ```bash
-   bash scripts/update-progress.sh <progress-path> merge <task-id> "clean"
+   bash scripts/update-progress.sh .prove/runs/<slug>/PROGRESS.md merge <task-id> "clean"
    ```
 
 2. After merging, clean up the worktree and its branch:
@@ -231,7 +246,7 @@ After ALL tasks in the wave are reviewed and approved:
    ```
 
 3. If merge conflict:
-   - Log: `update-progress.sh <path> merge <task-id> "conflict"`
+   - Log: `update-progress.sh .prove/runs/<slug>/PROGRESS.md merge <task-id> "conflict"`
    - Attempt auto-resolution for trivial conflicts
    - For non-trivial: ask user
 
@@ -333,7 +348,7 @@ Record commit SHA in run-log.
 
 ## Phase 3: Completion
 
-Generate `.prove/reports/<task-slug>/report.md`:
+Generate `.prove/runs/<task-slug>/reports/report.md`:
 
 ```markdown
 # Orchestrator Report: <Task Name>
@@ -431,9 +446,12 @@ Use `AskUserQuestion` with:
 If the user chose "Merge & Clean" or "Merge Only":
 
 ```bash
-git checkout main
+# Merge from the main worktree (not from inside the orchestrator worktree)
 git merge --no-ff orchestrator/<task-slug> -m "merge: <task-name>"
 ```
+
+If another orchestrator merged to main first, you may need to pull/merge main first.
+Standard git conflict resolution applies — this is the consolidation point for concurrent runs.
 
 If merge conflicts occur, halt and inform the user. Do NOT force-merge.
 
@@ -447,8 +465,8 @@ PROJECT_ROOT="." bash scripts/cleanup.sh --auto <task-slug>
 
 This will:
 1. Archive key documents to `.prove/archive/<date>_<task-slug>/`
-2. Remove `.prove/reports/<task-slug>/`, `.prove/plans/plan_*/`, `.prove/context/<task-slug>/`
-3. Remove `.prove/PRD.md`, `.prove/TASK_PLAN.md`, `.prove/PROGRESS.md`
+2. Remove `.prove/runs/<task-slug>/` (reports, progress, plan copies)
+3. Remove the orchestrator worktree: `git worktree remove .claude/worktrees/orchestrator-<task-slug> --force`
 4. Delete the merged `orchestrator/<task-slug>` branch
 
 Generate a `SUMMARY.md` in the archive directory (same as cleanup skill Phase 3).
@@ -468,7 +486,7 @@ If the user chose "Skip", remind them:
 
 ## Full Mode: Progress Tracking
 
-Maintain a live `.prove/PROGRESS.md` using `scripts/update-progress.sh`:
+Maintain a live `.prove/runs/<slug>/PROGRESS.md` using `scripts/update-progress.sh`:
 
 ```markdown
 # Progress: <Feature Name>
@@ -531,6 +549,8 @@ When triggered with "full auto" and no existing plan, run requirements gathering
 5. **Generate `.prove/TASK_PLAN.md`** with wave-based task graph
 6. **User approval gate** — Use AskUserQuestion with header "Plan" and options: "Approve" (begin execution) / "Request Changes" (I have feedback before proceeding)
 
+Note: PRD and TASK_PLAN are written to `.prove/` initially (shared). Phase 0 copies them into `.prove/runs/<slug>/` for run isolation.
+
 ---
 
 ## Error Handling
@@ -559,12 +579,25 @@ When triggered with "full auto" and no existing plan, run requirements gathering
 ## Conventions
 
 ### Branch Naming
-- Simple mode: `orchestrator/<task-slug>`
-- Full mode: `orchestrator/<feature-slug>`
-- Worktree branches: managed by `isolation: "worktree"`
+- Orchestrator branch: `orchestrator/<task-slug>` (lives in its own worktree at `.claude/worktrees/orchestrator-<slug>`)
+- Sub-task worktree branches: managed by `isolation: "worktree"` (full mode only)
 
 ### Slug Generation
 Kebab-case, max 40 chars: "Add user authentication" -> `add-user-authentication`
+
+### Run Directory Layout
+All per-run state lives under `.prove/runs/<slug>/`:
+```
+.prove/runs/<slug>/
+├── TASK_PLAN.md      # Copy of plan at run start
+├── PRD.md            # Copy of PRD at run start (if exists)
+├── PROGRESS.md       # Live progress tracking (full mode)
+├── dispatch-state.json  # Reporter deduplication state
+└── reports/
+    ├── run-log.md    # Audit trail
+    └── report.md     # Final report
+```
+This isolation allows multiple orchestrator runs to proceed concurrently.
 
 ## Scripts
 
@@ -574,8 +607,8 @@ Helper scripts live in `scripts/`:
 |--------|---------|
 | `generate-task-prompt.sh` | Generates a focused, self-contained prompt for worktree implementation agents |
 | `generate-review-prompt.sh` | Generates a structured review prompt for the principal-architect agent |
-| `update-progress.sh` | Updates .prove/PROGRESS.md with task/wave status changes |
-| `cleanup.sh` | Archives and removes .prove task artifacts (used by Phase 4 and `/task-cleanup`) |
+| `update-progress.sh` | Updates `.prove/runs/<slug>/PROGRESS.md` with task/wave status changes |
+| `cleanup.sh` | Archives and removes `.prove/runs/<slug>/` artifacts (used by Phase 4 and `/task-cleanup`) |
 
 ## References
 

--- a/skills/orchestrator/references/reporter-protocol.md
+++ b/skills/orchestrator/references/reporter-protocol.md
@@ -206,7 +206,7 @@ Hooks are configured in `.claude/settings.json` (project-level, committed to git
 
 ### Deduplication
 
-`dispatch-event.sh` maintains `.prove/dispatch-state.json` to prevent duplicate notifications. Each `(event, step)` tuple is dispatched at most once per orchestrator run.
+`dispatch-event.sh` maintains `.prove/runs/<slug>/dispatch-state.json` to prevent duplicate notifications. Each `(event, step)` tuple is dispatched at most once per orchestrator run. The slug is derived from the `PROVE_TASK` env var or the current branch name.
 
 ### Scripts
 


### PR DESCRIPTION
## Summary

- Orchestrator Phase 0 now creates a git worktree (`.claude/worktrees/orchestrator-<slug>`) instead of checking out in-place, so the main worktree stays untouched
- All per-run state (progress, reports, dispatch-state, plan copies) namespaced under `.prove/runs/<slug>/` — no more global singletons blocking concurrent runs
- Cleanup, dispatch hooks, session-stop, progress command, and docs all updated to support the new layout with backward compatibility for legacy paths

## Test plan

- [ ] Run `/prove:autopilot` on a single task — verify worktree is created at `.claude/worktrees/orchestrator-<slug>` and state lands in `.prove/runs/<slug>/`
- [ ] Run two orchestrators concurrently on different tasks — verify no contention on branches or state files
- [ ] Run `/prove:progress` with multiple active runs — verify summary table shows all
- [ ] Run `cleanup.sh --auto <slug>` after merge — verify `.prove/runs/<slug>/` and worktree are removed
- [ ] Run `cleanup.sh --dry-run` — verify it lists runs, worktrees, and legacy artifacts
- [ ] Verify reporter dispatch writes dedup state to `.prove/runs/<slug>/dispatch-state.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)