### PR TITLE
fix(orchestrator): prevent sub-task worktree collisions

### DIFF
--- a/commands/full-auto.md
+++ b/commands/full-auto.md
@@ -18,6 +18,6 @@ Load and follow the orchestrator skill (`skills/orchestrator/SKILL.md` from the 
 2. Write PRD and TASK_PLAN directly to `.prove/runs/<slug>/` (not to `.prove/` global)
 3. Gate on user approval between phases using `AskUserQuestion` (Approve / Request Changes)
 4. Create orchestrator worktree (`.claude/worktrees/orchestrator-<slug>`) — does not touch the main worktree
-5. Use `isolation: "worktree"` for parallel sub-task execution within the orchestrator worktree
+5. Use `scripts/manage-worktree.sh` for parallel sub-task worktrees (namespaced per slug to prevent collisions)
 6. Maintain `.prove/runs/<slug>/PROGRESS.md` throughout execution
 7. On completion, present a summary and offer to create a PR

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -141,25 +141,29 @@ For each wave:
 
 #### 2a. Launch Worktree Agents (parallel within wave)
 
-For each task in the wave, generate a prompt and launch:
+For each task in the wave:
 
-```bash
-# Generate the task prompt (use run-local copies)
-PROMPT=$(bash scripts/generate-task-prompt.sh \
-  .prove/runs/<slug>/TASK_PLAN.md <task-id> .prove/runs/<slug>/PRD.md <project-root>)
-```
+1. Create a namespaced worktree for the task:
+   ```bash
+   WT_PATH=$(bash scripts/manage-worktree.sh create <slug> <task-id>)
+   ```
 
-Then launch with the Agent tool:
-```
-Agent(
-  subagent_type: "general-purpose",
-  isolation: "worktree",
-  run_in_background: true,
-  prompt: $PROMPT
-)
-```
+2. Generate the task prompt (use run-local copies):
+   ```bash
+   PROMPT=$(bash scripts/generate-task-prompt.sh \
+     .prove/runs/<slug>/TASK_PLAN.md <task-id> .prove/runs/<slug>/PRD.md <project-root> "$WT_PATH")
+   ```
 
-- Launch ALL tasks in a wave as parallel Agent calls in a single message.
+3. Launch the agent **without** `isolation: "worktree"` — the worktree already exists:
+   ```
+   Agent(
+     subagent_type: "general-purpose",
+     run_in_background: true,
+     prompt: $PROMPT
+   )
+   ```
+
+- Create ALL worktrees first, then launch ALL agents as parallel Agent calls in a single message.
 - Update progress for each task start:
   ```bash
   bash scripts/update-progress.sh .prove/runs/<slug>/PROGRESS.md task-start <task-id>
@@ -182,8 +186,9 @@ For each completed worktree agent, run the review-fix loop:
 REVIEW LOOP (max 3 iterations per task):
 
 1. Generate review prompt:
+   WT_PATH=$(bash scripts/manage-worktree.sh path <slug> <task-id>)
    REVIEW_PROMPT=$(bash scripts/generate-review-prompt.sh \
-     <worktree-path> <task-id> .prove/runs/<slug>/TASK_PLAN.md .prove/runs/<slug>/PRD.md <base-branch>)
+     "$WT_PATH" <task-id> .prove/runs/<slug>/TASK_PLAN.md .prove/runs/<slug>/PRD.md <base-branch>)
 
 2. Launch principal-architect review:
    Agent(
@@ -231,17 +236,17 @@ After ALL tasks in the wave are reviewed and approved:
 1. For each approved task (in task order), merge into the orchestrator worktree:
    ```bash
    cd .claude/worktrees/orchestrator-<slug>
-   git merge <worktree-branch> --no-ff -m "merge: task <id> - <name>"
+   BRANCH=$(bash scripts/manage-worktree.sh branch <slug> <task-id>)
+   git merge "$BRANCH" --no-ff -m "merge: task <id> - <name>"
    ```
    Update progress:
    ```bash
    bash scripts/update-progress.sh .prove/runs/<slug>/PROGRESS.md merge <task-id> "clean"
    ```
 
-2. After merging, clean up the worktree and its branch:
+2. After merging, clean up the task worktree and its branch:
    ```bash
-   git worktree remove <worktree-path> --force
-   git branch -D <worktree-branch>
+   bash scripts/manage-worktree.sh remove <slug> <task-id>
    ```
 
 3. If merge conflict:
@@ -583,7 +588,8 @@ All artifacts are written directly to the run directory — no global `.prove/` 
 
 ### Branch Naming
 - Orchestrator branch: `orchestrator/<slug>` (lives in its own worktree at `.claude/worktrees/orchestrator-<slug>`)
-- Sub-task worktree branches: managed by `isolation: "worktree"` (full mode only)
+- Sub-task branches: `task/<slug>/<task-id>` (worktree at `.claude/worktrees/<slug>-task-<task-id>`)
+- Managed by `scripts/manage-worktree.sh` — deterministic naming prevents collisions between concurrent runs
 
 ### Slug Generation
 Kebab-case, max 40 chars: "Add user authentication" -> `add-user-authentication`

--- a/skills/orchestrator/scripts/generate-task-prompt.sh
+++ b/skills/orchestrator/scripts/generate-task-prompt.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # generate-task-prompt.sh — Generates a focused prompt for a worktree implementation agent.
 #
-# Usage: generate-task-prompt.sh <task-plan-path> <task-id> <prd-path> <project-root>
+# Usage: generate-task-prompt.sh <task-plan-path> <task-id> <prd-path> <project-root> [worktree-path]
 #
 # Reads TASK_PLAN.md and PRD, extracts the relevant task detail section,
 # and outputs a complete, self-contained prompt for a worktree agent.
+#
+# If worktree-path is provided, the prompt includes a directive to cd into it first.
 
 set -euo pipefail
 
@@ -12,6 +14,7 @@ TASK_PLAN="$1"
 TASK_ID="$2"
 PRD="$3"
 PROJECT_ROOT="$4"
+WORKTREE_PATH="${5:-}"
 
 if [[ ! -f "$TASK_PLAN" ]]; then
   echo "ERROR: TASK_PLAN.md not found at $TASK_PLAN" >&2
@@ -100,6 +103,20 @@ fi
 
 # Output the prompt
 cat <<PROMPT
+$(if [[ -n "$WORKTREE_PATH" ]]; then
+cat <<WORKTREE_BLOCK
+## Worktree
+
+You are working in a pre-created worktree. Before doing anything else, change into it:
+
+\`\`\`bash
+cd $WORKTREE_PATH
+\`\`\`
+
+All file reads, edits, and git commands must happen inside this directory.
+WORKTREE_BLOCK
+fi)
+
 You are implementing **Task $TASK_ID: $TASK_NAME**
 
 ## Task Details

--- a/skills/orchestrator/scripts/manage-worktree.sh
+++ b/skills/orchestrator/scripts/manage-worktree.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# manage-worktree.sh — Create, remove, and list namespaced sub-task worktrees.
+#
+# Prevents branch/path collisions between concurrent orchestrator runs by
+# deterministically namespacing worktree paths and branches under the
+# orchestrator slug.
+#
+# Usage:
+#   manage-worktree.sh create <slug> <task-id>
+#   manage-worktree.sh remove <slug> <task-id>
+#   manage-worktree.sh remove-all <slug>
+#   manage-worktree.sh list <slug>
+#   manage-worktree.sh path <slug> <task-id>
+#   manage-worktree.sh branch <slug> <task-id>
+#
+# Output (create): prints the absolute worktree path on success
+# Output (path):   prints the absolute worktree path (no creation)
+# Output (branch): prints the branch name (no creation)
+# Output (list):   prints one "<task-id> <worktree-path> <branch>" per line
+
+set -euo pipefail
+
+ACTION="${1:?Usage: manage-worktree.sh <create|remove|remove-all|list|path|branch> <slug> [task-id]}"
+SLUG="${2:?Missing slug}"
+TASK_ID="${3:-}"
+
+# Resolve the main worktree root (works from any worktree or the main repo)
+MAIN_ROOT=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+
+WORKTREE_DIR="$MAIN_ROOT/.claude/worktrees"
+
+# Deterministic naming:
+#   path:   .claude/worktrees/<slug>-task-<task-id>
+#   branch: task/<slug>/<task-id>
+#
+# Sub-task branches use the "task/" prefix (not "orchestrator/") to avoid git
+# ref conflicts — git cannot have both orchestrator/<slug> (file) and
+# orchestrator/<slug>/task-X (directory) in its ref tree.
+worktree_path() {
+  echo "$WORKTREE_DIR/${SLUG}-task-${1}"
+}
+
+branch_name() {
+  echo "task/${SLUG}/${1}"
+}
+
+case "$ACTION" in
+  create)
+    [[ -z "$TASK_ID" ]] && { echo "ERROR: task-id required for create" >&2; exit 1; }
+
+    WT_PATH=$(worktree_path "$TASK_ID")
+    BRANCH=$(branch_name "$TASK_ID")
+    BASE_BRANCH="orchestrator/${SLUG}"
+
+    # Verify the orchestrator branch exists (sub-tasks branch from it)
+    if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+      echo "ERROR: Base branch '$BASE_BRANCH' does not exist. Create the orchestrator worktree first." >&2
+      exit 1
+    fi
+
+    # Clean up stale worktree entry if path doesn't exist
+    if git worktree list --porcelain | grep -q "worktree $WT_PATH$" && [[ ! -d "$WT_PATH" ]]; then
+      git worktree prune
+    fi
+
+    # If worktree already exists, print path and exit (idempotent)
+    if [[ -d "$WT_PATH" ]]; then
+      echo "$WT_PATH"
+      exit 0
+    fi
+
+    # If branch exists but worktree doesn't, remove stale branch
+    if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+      git branch -D "$BRANCH" 2>/dev/null || true
+    fi
+
+    # Create worktree branching from the orchestrator branch
+    git worktree add "$WT_PATH" -b "$BRANCH" "$BASE_BRANCH"
+    echo "$WT_PATH"
+    ;;
+
+  remove)
+    [[ -z "$TASK_ID" ]] && { echo "ERROR: task-id required for remove" >&2; exit 1; }
+
+    WT_PATH=$(worktree_path "$TASK_ID")
+    BRANCH=$(branch_name "$TASK_ID")
+
+    if [[ -d "$WT_PATH" ]]; then
+      git worktree remove "$WT_PATH" --force 2>/dev/null || rm -rf "$WT_PATH"
+    fi
+    git worktree prune 2>/dev/null || true
+    git branch -D "$BRANCH" 2>/dev/null || true
+    ;;
+
+  remove-all)
+    # Remove all sub-task worktrees for this slug
+    for wt in "$WORKTREE_DIR/${SLUG}-task-"*; do
+      [[ -d "$wt" ]] || continue
+      git worktree remove "$wt" --force 2>/dev/null || rm -rf "$wt"
+    done
+    git worktree prune 2>/dev/null || true
+
+    # Remove all sub-task branches for this slug
+    git for-each-ref --format='%(refname:short)' "refs/heads/task/${SLUG}/" | while read -r branch; do
+      git branch -D "$branch" 2>/dev/null || true
+    done
+    ;;
+
+  list)
+    for wt in "$WORKTREE_DIR/${SLUG}-task-"*; do
+      [[ -d "$wt" ]] || continue
+      tid=$(basename "$wt" | sed "s/^${SLUG}-task-//")
+      branch=$(branch_name "$tid")
+      echo "$tid $wt $branch"
+    done
+    ;;
+
+  path)
+    [[ -z "$TASK_ID" ]] && { echo "ERROR: task-id required for path" >&2; exit 1; }
+    worktree_path "$TASK_ID"
+    ;;
+
+  branch)
+    [[ -z "$TASK_ID" ]] && { echo "ERROR: task-id required for branch" >&2; exit 1; }
+    branch_name "$TASK_ID"
+    ;;
+
+  *)
+    echo "ERROR: Unknown action '$ACTION'. Use: create, remove, remove-all, list, path, branch" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add `manage-worktree.sh` script to deterministically namespace sub-task worktrees by orchestrator slug
- Replace `isolation: "worktree"` Agent param with pre-created worktrees, eliminating branch/path collisions between concurrent orchestrator runs
- Use `task/<slug>/<id>` branch prefix (separate from `orchestrator/<slug>`) to avoid git ref hierarchy conflicts

## Test plan
- [x] Verified two concurrent orchestrator slugs can both have `task-1.1` without collision
- [x] Tested idempotent create, single remove, remove-all, list, path, branch commands
- [x] Confirmed full cleanup leaves no stale worktrees or branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)