### PR TITLE
fix: async runBin in install tests — spawnSync deadlocked the in-process stub server

### DIFF
--- a/packages/cli/test/install-latest.test.ts
+++ b/packages/cli/test/install-latest.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -20,16 +20,27 @@ interface RunResult {
   status: number;
 }
 
-function runBin(args: string[], env: Record<string, string>): RunResult {
-  const result = spawnSync('bun', ['run', BIN, ...args], {
-    encoding: 'utf8',
-    env: { ...process.env, NODE_ENV: 'test', ...env },
+// Async spawn, not spawnSync: the remote-resolution suite serves its GitHub
+// stub from THIS process via Bun.serve, and a synchronous child wait blocks
+// the event loop the stub needs to answer — the child then hangs until its
+// own fetch timeout aborts. Awaiting an async child keeps the loop free.
+function runBin(args: string[], env: Record<string, string>): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('bun', ['run', BIN, ...args], {
+      env: { ...process.env, NODE_ENV: 'test', ...env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => {
+      stdout += d;
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.on('close', (status) => {
+      resolve({ stdout, stderr, status: status ?? -1 });
+    });
   });
-  return {
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-    status: result.status ?? -1,
-  };
 }
 
 /** Build a fake `plugin list` command that prints the given JSON payload. */
@@ -42,7 +53,7 @@ function stubPluginList(payload: unknown): string {
 }
 
 describe('claude-prove install latest — local resolution', () => {
-  test('picks the highest-semver prove@prove entry', () => {
+  test('picks the highest-semver prove@prove entry', async () => {
     const listPayload = [
       {
         id: 'prove@prove',
@@ -67,7 +78,7 @@ describe('claude-prove install latest — local resolution', () => {
       },
     ];
 
-    const { stdout, status } = runBin(['install', 'latest', '--offline'], {
+    const { stdout, status } = await runBin(['install', 'latest', '--offline'], {
       PROVE_PLUGIN_LIST_CMD: stubPluginList(listPayload),
     });
 
@@ -84,8 +95,8 @@ describe('claude-prove install latest — local resolution', () => {
     expect(parsed.errors).toEqual({});
   });
 
-  test('reports a local error when no prove@prove entry exists', () => {
-    const { stdout, status } = runBin(['install', 'latest', '--offline'], {
+  test('reports a local error when no prove@prove entry exists', async () => {
+    const { stdout, status } = await runBin(['install', 'latest', '--offline'], {
       PROVE_PLUGIN_LIST_CMD: stubPluginList([]),
     });
 
@@ -95,8 +106,8 @@ describe('claude-prove install latest — local resolution', () => {
     expect(parsed.errors.local).toContain('no prove@prove entry');
   });
 
-  test('reports a local error when the list command fails', () => {
-    const { stdout, status } = runBin(['install', 'latest', '--offline'], {
+  test('reports a local error when the list command fails', async () => {
+    const { stdout, status } = await runBin(['install', 'latest', '--offline'], {
       PROVE_PLUGIN_LIST_CMD: 'false',
     });
 
@@ -136,7 +147,7 @@ describe('claude-prove install latest — remote resolution', () => {
     server.stop(true);
   });
 
-  test('fetches tag_name + html_url and computes upToDate=false when versions diverge', () => {
+  test('fetches tag_name + html_url and computes upToDate=false when versions diverge', async () => {
     const listPayload = [
       {
         id: 'prove@prove',
@@ -147,7 +158,7 @@ describe('claude-prove install latest — remote resolution', () => {
       },
     ];
 
-    const { stdout, status } = runBin(['install', 'latest'], {
+    const { stdout, status } = await runBin(['install', 'latest'], {
       PROVE_PLUGIN_LIST_CMD: stubPluginList(listPayload),
       PROVE_GH_API_BASE: baseUrl,
     });
@@ -162,7 +173,7 @@ describe('claude-prove install latest — remote resolution', () => {
     expect(parsed.upToDate).toBe(false);
   });
 
-  test('computes upToDate=true when local matches remote', () => {
+  test('computes upToDate=true when local matches remote', async () => {
     const listPayload = [
       {
         id: 'prove@prove',
@@ -173,7 +184,7 @@ describe('claude-prove install latest — remote resolution', () => {
       },
     ];
 
-    const { stdout, status } = runBin(['install', 'latest'], {
+    const { stdout, status } = await runBin(['install', 'latest'], {
       PROVE_PLUGIN_LIST_CMD: stubPluginList(listPayload),
       PROVE_GH_API_BASE: baseUrl,
     });
@@ -183,7 +194,7 @@ describe('claude-prove install latest — remote resolution', () => {
     expect(parsed.upToDate).toBe(true);
   });
 
-  test('remote=null and error reported when releases API 404s', () => {
+  test('remote=null and error reported when releases API 404s', async () => {
     const listPayload = [
       {
         id: 'prove@prove',
@@ -194,7 +205,7 @@ describe('claude-prove install latest — remote resolution', () => {
       },
     ];
 
-    const { stdout, status } = runBin(['install', 'latest'], {
+    const { stdout, status } = await runBin(['install', 'latest'], {
       PROVE_PLUGIN_LIST_CMD: stubPluginList(listPayload),
       PROVE_GH_API_BASE: `${baseUrl}/missing`,
     });

--- a/packages/cli/test/install-upgrade.test.ts
+++ b/packages/cli/test/install-upgrade.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -33,24 +33,35 @@ interface RunEnv {
   PROVE_FORCE_MODE?: string;
 }
 
-function runBin(args: string[], env: RunEnv): RunResult {
-  const result = spawnSync('bun', ['run', BIN, ...args], {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      // The session may inject CLAUDE_PROVE_PLUGIN_DIR (settings.local.json
-      // env block), which outranks the CLAUDE_PLUGIN_ROOT pins these tests
-      // rely on for mode detection. Empty string = unset for the resolver.
-      CLAUDE_PROVE_PLUGIN_DIR: '',
-      NODE_ENV: 'test',
-      ...env,
-    },
+// Async spawn, not spawnSync: the stubbed-CDN suite serves its payload from
+// THIS process via Bun.serve, and a synchronous child wait blocks the event
+// loop the stub needs to answer — the child then hangs until its own fetch
+// timeout aborts. Awaiting an async child keeps the loop free.
+function runBin(args: string[], env: RunEnv): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn('bun', ['run', BIN, ...args], {
+      env: {
+        ...process.env,
+        // The session may inject CLAUDE_PROVE_PLUGIN_DIR (settings.local.json
+        // env block), which outranks the CLAUDE_PLUGIN_ROOT pins these tests
+        // rely on for mode detection. Empty string = unset for the resolver.
+        CLAUDE_PROVE_PLUGIN_DIR: '',
+        NODE_ENV: 'test',
+        ...env,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => {
+      stdout += d;
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.on('close', (status) => {
+      resolve({ stdout, stderr, status: status ?? -1 });
+    });
   });
-  return {
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-    status: result.status ?? -1,
-  };
 }
 
 function makeCompiledPluginFixture(): string {
@@ -70,19 +81,19 @@ function currentTarget(): string {
 }
 
 describe('claude-prove install upgrade — dev provenance', () => {
-  test('a bun-run source invocation exits 1 with the dev-mode error', () => {
-    const { stderr, status } = runBin(['install', 'upgrade'], {});
+  test('a bun-run source invocation exits 1 with the dev-mode error', async () => {
+    const { stderr, status } = await runBin(['install', 'upgrade'], {});
     expect(status).toBe(1);
     expect(stderr).toContain('upgrade is a compiled-mode command; use git pull in dev checkouts');
   });
 
-  test('plugin-root env vars cannot flip a source invocation to compiled', () => {
+  test('plugin-root env vars cannot flip a source invocation to compiled', async () => {
     // Provenance wins: even a compiled-shaped plugin root (no packages/cli/src)
     // pinned via both env vars must not unlock the download path when the
     // process itself runs from sources.
     const pluginRoot = makeCompiledPluginFixture();
     try {
-      const { stderr, status } = runBin(['install', 'upgrade'], {
+      const { stderr, status } = await runBin(['install', 'upgrade'], {
         CLAUDE_PLUGIN_ROOT: pluginRoot,
         CLAUDE_PROVE_PLUGIN_DIR: pluginRoot,
       });
@@ -93,8 +104,8 @@ describe('claude-prove install upgrade — dev provenance', () => {
     }
   });
 
-  test('PROVE_FORCE_MODE=dev refuses even when set explicitly', () => {
-    const { status, stderr } = runBin(['install', 'upgrade'], { PROVE_FORCE_MODE: 'dev' });
+  test('PROVE_FORCE_MODE=dev refuses even when set explicitly', async () => {
+    const { status, stderr } = await runBin(['install', 'upgrade'], { PROVE_FORCE_MODE: 'dev' });
     expect(status).toBe(1);
     expect(stderr).toContain('upgrade is a compiled-mode command');
   });
@@ -129,10 +140,10 @@ describe('claude-prove install upgrade — compiled mode with stubbed CDN', () =
     server.stop(true);
   });
 
-  test('downloads payload, chmods +x, and atomic-renames to --prefix', () => {
+  test('downloads payload, chmods +x, and atomic-renames to --prefix', async () => {
     const prefix = mkdtempSync(join(tmpdir(), 'prove-install-upgrade-prefix-'));
     try {
-      const { stdout, stderr, status } = runBin(['install', 'upgrade', '--prefix', prefix], {
+      const { stdout, stderr, status } = await runBin(['install', 'upgrade', '--prefix', prefix], {
         ...FORCE,
         PROVE_RELEASE_URL_BASE: baseUrl,
       });
@@ -157,10 +168,10 @@ describe('claude-prove install upgrade — compiled mode with stubbed CDN', () =
     }
   });
 
-  test('exits 1 when the CDN responds with 404', () => {
+  test('exits 1 when the CDN responds with 404', async () => {
     const prefix = mkdtempSync(join(tmpdir(), 'prove-install-upgrade-404-'));
     try {
-      const { stderr, status } = runBin(['install', 'upgrade', '--prefix', prefix], {
+      const { stderr, status } = await runBin(['install', 'upgrade', '--prefix', prefix], {
         ...FORCE,
         // Point at a path the stub returns 404 for.
         PROVE_RELEASE_URL_BASE: `${baseUrl}/missing`,


### PR DESCRIPTION
## Problem

The `install-latest` and `install-upgrade` test suites serve their GitHub-API/CDN stubs from the test process itself via `Bun.serve`, but `runBin()` waited on the spawned CLI child with **`spawnSync`** — which blocks Bun's event loop, so the in-process stub can never answer the child's request. The child hangs until its own 5s fetch abort fires, then exits with the wrong result.

On Bun 1.3.14 this fails 5 tests deterministically and costs ~320s of suite wall-clock (one test rides its 300s timeout). The suites presumably passed on the pinned Bun 1.2.22, where serve I/O survived a blocked loop.

Repro evidence: instrumenting the stub shows it is **never hit** under `spawnSync`; the identical invocation via async `spawn` hits the stub and completes in ~50ms.

## Fix

`runBin` becomes an awaited async `spawn` (promise-wrapped) in both files; test callbacks become `async`. No source code touched — test-only change.

## Result

- `bun test`: **3,132 pass / 0 fail** (was 6 fail: these 5 + a branch-local golden artifact)
- Suite wall-clock: **343s → 23s**
- The remote-resolution/stubbed-CDN tests now actually exercise their stubs instead of silently asserting on the abort path

🤖 Generated with [Claude Code](https://claude.com/claude-code)