### PR TITLE
fix: workers land typed findings on normal completion so curation sweeps them

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -8,6 +8,17 @@ For the full commit-level changelog, see [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
+## Unreleased — Worker prompt lands typed findings; milestone-close curation sweeps them
+
+*(No `.claude/.prove.json` migration, no store migration — prompt template + skill behavior.)* Fixes the worker/driver protocol gap where milestone-close curation swept 0 candidates after orchestrator full-mode runs ([#51](https://github.com/mjmorales/claude-prove/issues/51)). The `orchestrator task-prompt` template documented `acb log append` only on the cooperative-cancel path, so worker findings reached the driver solely in handoff messages, got folded into driver `synthesis` entries, and never hit the typed kinds (`hack`/`risk`/`decision`/`assumption`) the curation reconciler sweeps.
+
+- **Worker prompt — "Typed Findings" section** (`orchestrator task-prompt`): on normal completion, each task subagent records its substantive findings as typed reasoning-log entries (one JSON file via the Write tool, landed with `claude-prove acb log append --run-dir <dir> --file <entry.json>`, `agent: task-<id>`). These are file appends into the main worktree run dir — exempt from the worker shared-store ban. The worker exit contract is now: record typed findings → commit → exit.
+- **Driver findings backstop** (orchestrator + workflow skills): when a worker's handoff message reports findings missing from the reasoning log, the driver transcribes them as typed entries (`agent: "driver"`) before writing `synthesis` — never folds them into `synthesis` prose alone.
+
+Migration: none — the template change applies to the next dispatched run. Auto-adoption: full; no config or store changes.
+
+---
+
 ## v3.13.0 — Lore supersession + `scrum lore promote`/`supersede` (store v28)
 
 *(Store migration v28 — auto-applies on the next `claude-prove scrum` open; no `.claude/.prove.json` migration.)* `scrum_lores` gains the compaction lifecycle: `superseded_by` (a typed soft reference — `lore:<id>` for a consolidation, `decision:<id>` for a promotion) plus `reason`. Rows are never edited or deleted — a retired entry keeps its body, author, and timestamp; only the pointer lands, and a supersession is resolved once. New CLI surface:

--- a/packages/cli/src/topics/orchestrator/task-prompt.test.ts
+++ b/packages/cli/src/topics/orchestrator/task-prompt.test.ts
@@ -147,6 +147,31 @@ describe('orchestrator task-prompt', () => {
     expect(stdoutBuf).toContain('token budget and subagent timeout remain the hard backstop');
   });
 
+  test('typed-findings protocol on the normal-completion path (curation sweep input)', () => {
+    writePlan(BASE_PLAN);
+    writePrd(BASE_PRD);
+    const code = runTaskPrompt({ runDir, taskId: '1', projectRoot: project });
+    expect(code).toBe(0);
+    expect(stdoutBuf).toContain('## Typed Findings — record before exiting');
+    // The four curation-swept entry types render with their required fields.
+    expect(stdoutBuf).toContain('- `hack` —');
+    expect(stdoutBuf).toContain('`cleanup_condition` (string)');
+    expect(stdoutBuf).toContain('- `risk` —');
+    expect(stdoutBuf).toContain('`"low"|"medium"|"high"|"critical"`');
+    expect(stdoutBuf).toContain('- `decision` —');
+    expect(stdoutBuf).toContain('`selected_rationale` (string)');
+    expect(stdoutBuf).toContain('- `assumption` —');
+    expect(stdoutBuf).toContain('`resolution_ref` (string or null)');
+    // Per-task agent provenance derived from the task id.
+    expect(stdoutBuf).toContain('`task-1`');
+    // Applies on normal completion — not only the cooperative-cancel path.
+    expect(stdoutBuf).toContain('NORMAL completion');
+    // The When Done contract leads with the findings step.
+    expect(stdoutBuf).toContain(
+      '1. Record every substantive finding as a typed reasoning-log entry',
+    );
+  });
+
   test('forbids opening the shared store from the worktree (no schema pollution)', () => {
     writePlan(BASE_PLAN);
     writePrd(BASE_PRD);
@@ -176,8 +201,11 @@ describe('orchestrator task-prompt', () => {
       const absRunDir = join(root, 'run');
       expect(stdoutBuf).toContain(`test -f "${join(absRunDir, 'CANCEL')}"`);
       expect(stdoutBuf).toContain(`claude-prove acb log append --run-dir "${absRunDir}"`);
-      // No bare relative flag path leaks into the emitted worker prompt.
+      // No bare relative flag path leaks into the emitted worker prompt —
+      // neither the cancel-flag read nor any append command (checkpoint
+      // handoff AND typed-findings sections share the absolutized run dir).
       expect(stdoutBuf).not.toContain('test -f "run/CANCEL"');
+      expect(stdoutBuf).not.toContain('--run-dir "run"');
     } finally {
       process.chdir(prevCwd);
     }

--- a/packages/cli/src/topics/orchestrator/task-prompt.ts
+++ b/packages/cli/src/topics/orchestrator/task-prompt.ts
@@ -143,6 +143,12 @@ function renderTaskPrompt(input: RenderInput): string {
   const ac = task.acceptance_criteria ?? [];
   const steps = task.steps ?? [];
   const prdAc = prd.acceptance_criteria ?? [];
+  // A relative run dir is absolutized against projectRoot (the main worktree
+  // root) — the worker cd's into its task worktree, where `.prove/` is
+  // gitignored and absent, so a relative path would silently miss the run dir.
+  const resolvedRunDir = isAbsolute(opts.runDir)
+    ? opts.runDir
+    : join(opts.projectRoot, opts.runDir);
 
   const sections: string[] = [];
 
@@ -256,7 +262,9 @@ function renderTaskPrompt(input: RenderInput): string {
     ].join('\n'),
   );
   sections.push('');
-  sections.push(renderCheckpointInterrupt(opts.runDir, opts.projectRoot));
+  sections.push(renderCheckpointInterrupt(resolvedRunDir));
+  sections.push('');
+  sections.push(renderTypedFindings(resolvedRunDir, taskIdStr));
   sections.push('');
   sections.push('## When Done');
   sections.push('');
@@ -270,8 +278,9 @@ function renderTaskPrompt(input: RenderInput): string {
   sections.push('');
   sections.push(
     [
-      '1. Produce at least one commit on this worktree branch containing the intended change.',
-      '2. Exit.',
+      '1. Record every substantive finding as a typed reasoning-log entry (see "Typed Findings" above).',
+      '2. Produce at least one commit on this worktree branch containing the intended change.',
+      '3. Exit.',
     ].join('\n'),
   );
   sections.push('');
@@ -294,13 +303,12 @@ function renderTaskPrompt(input: RenderInput): string {
  * or stuck worker will not stop here — the token budget / subagent timeout
  * (Layer 1) remains the hard backstop.
  *
- * A relative run dir is absolutized against `projectRoot` (the main worktree
- * root), so the embedded flag path and handoff-append command target the main
- * worktree's `.prove/runs/...` tree — never the worker's own task worktree,
- * where `.prove/` is gitignored and absent.
+ * Receives the already-absolutized run dir, so the embedded flag path and
+ * handoff-append command target the main worktree's `.prove/runs/...` tree —
+ * never the worker's own task worktree, where `.prove/` is gitignored and
+ * absent.
  */
-function renderCheckpointInterrupt(runDir: string, projectRoot: string): string {
-  const resolvedRunDir = isAbsolute(runDir) ? runDir : join(projectRoot, runDir);
+function renderCheckpointInterrupt(resolvedRunDir: string): string {
   const cancelFlag = join(resolvedRunDir, 'CANCEL');
   return [
     '## Cooperative checkpoint-interrupt (Layer 2)',
@@ -318,6 +326,45 @@ function renderCheckpointInterrupt(runDir: string, projectRoot: string): string 
     '3. Self-exit; do not continue past the checkpoint.',
     '',
     'This path is best-effort and layers ON TOP of the Layer-1 cancel-and-redispatch floor — it never replaces it. When you are mid-step or cannot stop cleanly, keep working: the token budget and subagent timeout remain the hard backstop.',
+  ].join('\n');
+}
+
+/**
+ * Typed-findings protocol for the normal-completion path.
+ *
+ * Without this section, worker findings reach the driver only inside the
+ * final handoff message, get folded into driver `synthesis` entries, and
+ * milestone-close curation — which mechanically sweeps only the typed kinds
+ * `hack`/`risk`/`decision`/`assumption` — proposes zero candidates. Workers
+ * CAN write these entries from a worktree: `acb log append` is a file append
+ * into the main worktree's run dir, not a store-opening command, so the
+ * shared-store ban in Resource Constraints does not apply to it.
+ *
+ * The `agent` value `task-<id>` keeps per-worker provenance in the
+ * `log/<agent>/` layout, matching the `task/<slug>/<id>` branch convention.
+ */
+function renderTypedFindings(resolvedRunDir: string, taskIdStr: string): string {
+  return [
+    '## Typed Findings — record before exiting',
+    '',
+    'Findings that should outlive this run MUST land in the reasoning log as typed entries — these are file appends into the main worktree run dir, not store-opening commands, so the shared-store ban in Resource Constraints does not apply. A finding mentioned only in your final handoff message is dropped: milestone-close curation sweeps typed entries, never handoff prose. This applies on NORMAL completion, not just on cancel.',
+    '',
+    'Record one entry per substantive finding, choosing the type by what you found:',
+    '',
+    '- `hack` — a shortcut or temporary workaround you shipped. Extra fields: `file_refs` (string[]), `cleanup_condition` (string).',
+    '- `risk` — fragility or danger you saw but did not fix. Extra fields: `severity` (`"low"|"medium"|"high"|"critical"`), `mitigation` (string).',
+    '- `decision` — a choice between defensible options. Extra fields: `alternatives` (string[]), `selected_rationale` (string).',
+    '- `assumption` — something you proceeded on without verifying. Extra fields: `resolved` (boolean), `resolution_ref` (string or null).',
+    '',
+    `Each entry is one JSON object with the envelope fields — \`id\` (fresh UUID), \`ts\` (ISO-8601), \`type\`, \`agent\` (use \`task-${taskIdStr}\`), \`run_path\` (the run dir below), \`body\` (the finding itself, in prose) — plus the type's extra fields. Validation is strict and closed: unknown types or extra keys are rejected, so put detail in \`body\`, never in new keys.`,
+    '',
+    'Compose each entry file with the Write tool (Bash heredocs mangle multi-line prose), then land it:',
+    '',
+    '```bash',
+    `claude-prove acb log append --run-dir "${resolvedRunDir}" --file <entry.json>`,
+    '```',
+    '',
+    'A clean run with nothing worth recording appends nothing — do not invent findings. Still summarize your findings in the final handoff message; the typed entries are the durable record, the handoff is for the driver.',
   ].join('\n');
 }
 

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -167,7 +167,9 @@ The SubagentStop hook auto-completes the step with the subagent's latest commit 
   scripts/prove-run report <step_id> --status completed --commit <SHA>
   ```
 
-Sub-agents themselves must NOT call `scripts/prove-run step-complete` — the orchestrator owns step transitions and the hook is the safety net. Their contract is: commit, exit.
+Sub-agents themselves must NOT call `scripts/prove-run step-complete` — the orchestrator owns step transitions and the hook is the safety net. Their contract is: record typed findings, commit, exit.
+
+**Findings backstop (per completed task).** The task prompt instructs each worker to land its substantive findings as typed reasoning-log entries — `hack`/`risk`/`decision`/`assumption`, the kinds milestone-close curation mechanically sweeps. A finding that exists only in the worker's handoff message is invisible to curation. When a handoff message reports findings, verify they landed: `claude-prove acb log list --run-dir "$RUN_DIR"` (worker entries carry `agent: "task-<task-id>"`). Transcribe any missing finding yourself as a typed entry (`agent: "driver"`, the finding prose in `body`, plus the type's required fields) via `claude-prove acb log append --run-dir "$RUN_DIR" --file <entry.json>`. Never fold worker findings into `synthesis` prose alone — `synthesis` is not swept.
 
 #### 2c. Validation Gate (per task)
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -105,8 +105,11 @@ Then drive the standard full-mode loop (`skills/orchestrator/SKILL.md`, "Full Mo
 over those batches: create a worktree per task → launch one `general-purpose` subagent
 per task, each prompted via `claude-prove orchestrator task-prompt --run-dir <dir>
 --task-id <id>` → run validators → `principal-architect` review loop → sequential
-merge-back. As in orchestrator full mode, subagents only commit and exit; you own every
-step and scrum write.
+merge-back. As in orchestrator full mode, subagents record typed findings, commit, and
+exit; you own every step and scrum write — including the findings backstop: when a
+worker's handoff message reports findings missing from the reasoning log, transcribe
+them as typed `hack`/`risk`/`decision`/`assumption` entries before writing `synthesis`,
+so milestone-close curation can sweep them.
 
 One delta this skill applies beyond the schedule:
 


### PR DESCRIPTION
Fixes #51.

## Problem

Milestone-close curation swept 0 candidates after orchestrator full-mode runs. The `orchestrator task-prompt` template documented `acb log append` only on the cooperative-cancel path, so worker findings reached the driver solely in handoff messages, got folded into driver `synthesis` entries, and the curation reconciler — which sweeps only the typed kinds `hack`/`risk`/`decision`/`assumption` (`CURATION_ENTRY_TYPES`) — never saw them.

## Fix

Fix (a) from the issue, with the driver backstop as belt-and-braces:

- **`task-prompt.ts`** — new `## Typed Findings — record before exiting` worker-prompt section: the four curation-swept entry types with their exact required fields (verified against `TYPE_SPECS` in `reasoning-log.ts`), the strict-closed validation contract, `agent: task-<id>` provenance, and an explicit exemption from the shared-store ban (file appends, not store opens). The When Done contract is now record typed findings → commit → exit. Run-dir absolutization is hoisted so the checkpoint-interrupt and typed-findings sections share one resolved path.
- **`skills/orchestrator/SKILL.md` (2b)** — driver findings backstop: verify worker entries landed via `acb log list`; transcribe any handoff-only finding as a typed entry (`agent: "driver"`) before writing `synthesis`.
- **`skills/workflow/SKILL.md`** — subagent contract updated to match; defers backstop mechanics to the orchestrator skill.
- **UPDATES.md** — `## Unreleased` entry (no config or store migration; applies to the next dispatched run).

## Validation

- 11/11 `task-prompt.test.ts` (new typed-findings coverage + tightened relative-run-dir leak assertions), 307/307 orchestrator+acb suites
- `tsc --build`, `biome check` clean
- `llm-prompt-engineer` gate: PASS (3 LOW findings applied: folded redundant store-ban restatement into the lead, template-literal cleanup, split the dense backstop sentence)
- `comment-audit`: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)